### PR TITLE
feat: start keys

### DIFF
--- a/airbyte-integrations/connectors/source-kyve/integration_tests/acceptance.py
+++ b/airbyte-integrations/connectors/source-kyve/integration_tests/acceptance.py
@@ -13,8 +13,7 @@ def pytest_collection_modifyitems(config, items):
     skip_cursor = pytest.mark.skip(reason="MANUALLY SKIPPED: Cursor never in schema")
     for item in items:
         if (
-            "test_defined_cursors_exist_in_schema" in item.name
-            or "test_read_sequential_slices" in item.name
+            "test_read_sequential_slices" in item.name
             or "test_two_sequential_reads" in item.name
         ):
             item.add_marker(skip_cursor)

--- a/airbyte-integrations/connectors/source-kyve/integration_tests/config.json
+++ b/airbyte-integrations/connectors/source-kyve/integration_tests/config.json
@@ -2,6 +2,7 @@
   "pool_ids": "0",
   "start_ids": "0",
   "url_base": "https://api-eu-1.kyve.network",
+  "start_keys": "0",
   "page_size": 1,
   "max_pages": 2
 }

--- a/airbyte-integrations/connectors/source-kyve/integration_tests/multiple_pools_config.json
+++ b/airbyte-integrations/connectors/source-kyve/integration_tests/multiple_pools_config.json
@@ -2,6 +2,7 @@
   "pool_ids": "0,1",
   "start_ids": "0,0",
   "url_base": "https://api-eu-1.kyve.network",
+  "start_keys": "0,0",
   "page_size": 1,
   "max_pages": 2
 }

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
@@ -17,10 +17,14 @@ class SourceKyve(AbstractSource):
         # check that pools and bundles are the same length
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
-        start_keys = config.get("start_keys").split(",")
 
-        if not len(pools) == len(start_ids) == len(start_keys):
-            return False, "Please add a start_id and start_keys for every pool"
+        if config.get("start_keys") != "":
+            start_keys = config.get("start_keys").split(",")
+            if not len(pools) == len(start_ids) == len(start_keys):
+                return False, "Please add a start_id and a start_key for every pool"
+        else:
+            if not len(pools) == len(start_ids):
+                return False, "Please add a start_id for every pool"
 
         for pool_id in pools:
             try:
@@ -39,16 +43,27 @@ class SourceKyve(AbstractSource):
 
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
-        start_keys = config.get("start_keys").split(",")
 
-        for (pool_id, start_id, start_key) in zip(pools, start_ids, start_keys):
-            response = requests.get(f"{config['url_base']}/kyve/query/v1beta1/pool/{pool_id}")
-            pool_data = response.json().get("pool").get("data")
+        if config.get("start_keys") != "":
+            start_keys = config.get("start_keys").split(",")
+            for (pool_id, start_id, start_key) in zip(pools, start_ids, start_keys):
+                response = requests.get(f"{config['url_base']}/kyve/query/v1beta1/pool/{pool_id}")
+                pool_data = response.json().get("pool").get("data")
 
-            config_copy = dict(deepcopy(config))
-            config_copy["start_ids"] = int(start_id)
-            config_copy["start_keys"] = int(start_key)
-            # add a new stream based on the pool_data
-            streams.append(KYVEStream(config=config_copy, pool_data=pool_data))
+                config_copy = dict(deepcopy(config))
+                config_copy["start_ids"] = int(start_id)
+                config_copy["start_keys"] = int(start_key)
+                # add a new stream based on the pool_data
+                streams.append(KYVEStream(config=config_copy, pool_data=pool_data))
+        else:
+            for (pool_id, start_id) in zip(pools, start_ids):
+                response = requests.get(f"{config['url_base']}/kyve/query/v1beta1/pool/{pool_id}")
+                pool_data = response.json().get("pool").get("data")
+
+                config_copy = dict(deepcopy(config))
+                config_copy["start_ids"] = int(start_id)
+                config_copy["start_keys"] = -1
+                # add a new stream based on the pool_data
+                streams.append(KYVEStream(config=config_copy, pool_data=pool_data))
 
         return streams

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
@@ -18,7 +18,7 @@ class SourceKyve(AbstractSource):
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
 
-        if config.get("start_keys") != "":
+        if config.get("start_keys"):
             start_keys = config.get("start_keys").split(",")
             if not len(pools) == len(start_ids) == len(start_keys):
                 return False, "Please add a start_id and a start_key for every pool"
@@ -44,7 +44,7 @@ class SourceKyve(AbstractSource):
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
 
-        if config.get("start_keys") != "":
+        if config.get("start_keys"):
             start_keys = config.get("start_keys").split(",")
             for (pool_id, start_id, start_key) in zip(pools, start_ids, start_keys):
                 response = requests.get(f"{config['url_base']}/kyve/query/v1beta1/pool/{pool_id}")

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
@@ -24,8 +24,8 @@ class SourceKyve(AbstractSource):
                 return False, "Please add a start_id and a start_key for every pool"
 
         if config.get("end_keys"):
-            start_keys = config.get("end_keys").split(",")
-            if not len(pools) == len(start_ids) == len(start_keys):
+            end_keys = config.get("end_keys").split(",")
+            if not len(pools) == len(start_ids) == len(end_keys):
                 return False, "Please add a start_id and a end_key for every pool"
 
         if not len(pools) == len(start_ids):
@@ -55,8 +55,8 @@ class SourceKyve(AbstractSource):
 
             config_copy = dict(deepcopy(config))
             config_copy["start_ids"] = int(start_id)
-            config_copy["start_keys"] = -float('inf')
-            config_copy["end_keys"] = float('inf')
+            config_copy["start_keys"] = int(-1e18)
+            config_copy["end_keys"] = int(1e18)
 
             if config.get("start_keys"):
                 config_copy["start_keys"] = int(config.get("start_keys").split(",")[i])

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/source.py
@@ -17,9 +17,10 @@ class SourceKyve(AbstractSource):
         # check that pools and bundles are the same length
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
+        start_keys = config.get("start_keys").split(",")
 
-        if not len(pools) == len(start_ids):
-            return False, "Please add a start_id for every pool"
+        if not len(pools) == len(start_ids) == len(start_keys):
+            return False, "Please add a start_id and start_keys for every pool"
 
         for pool_id in pools:
             try:
@@ -38,13 +39,15 @@ class SourceKyve(AbstractSource):
 
         pools = config.get("pool_ids").split(",")
         start_ids = config.get("start_ids").split(",")
+        start_keys = config.get("start_keys").split(",")
 
-        for (pool_id, start_id) in zip(pools, start_ids):
+        for (pool_id, start_id, start_key) in zip(pools, start_ids, start_keys):
             response = requests.get(f"{config['url_base']}/kyve/query/v1beta1/pool/{pool_id}")
             pool_data = response.json().get("pool").get("data")
 
             config_copy = dict(deepcopy(config))
             config_copy["start_ids"] = int(start_id)
+            config_copy["start_keys"] = int(start_key)
             # add a new stream based on the pool_data
             streams.append(KYVEStream(config=config_copy, pool_data=pool_data))
 

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
@@ -47,6 +47,19 @@ connectionSpecification:
         - "0"
         - "0,0"
         - "42000"
+    end_keys:
+      type: string
+      title: End keys
+      description:
+        The end key defines, until which key the pipeline should
+        extract the data. Only recommended when the sync should
+        end at a specific key to prevent unnecessary data traffic. 
+        Right now, this is only supported for pools using the kyvejs/tendermint 
+        or kyvejs/tendermint-bsync runtime. (Comma separated)
+      examples:
+        - "100"
+        - "20,10"
+        - "42300"
     max_pages:
       type: integer
       description:

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
@@ -6,6 +6,7 @@ connectionSpecification:
   required:
     - pool_ids
     - start_ids
+    - start_keys
     - url_base
   properties:
     pool_ids:
@@ -35,12 +36,24 @@ connectionSpecification:
       examples:
         - https://api.kaon.kyve.network/
         - https://api.korellia.kyve.network/
+    start_keys:
+      type: string
+      title: Start keys
+      description:
+        The start key defines, from which key the pipeline should
+        start to extract the data. Only recommended when the sync should 
+        start at a specific key with a predefined Bundle-Start-ID to prevent 
+        inefficiency. (Comma separated)
+      order: 3
+      examples:
+        - "0"
+        - "0,0"
     max_pages:
       type: integer
       description:
         The maximum amount of pages to go trough. Set to 'null' for all
         pages.
-      order: 3
+      order: 4
       airbyte_hidden: true
     page_size:
       type: integer
@@ -48,5 +61,5 @@ connectionSpecification:
         The pagesize for pagination, smaller numbers are used in integration
         tests.
       default: 100
-      order: 4
+      order: 5
       airbyte_hidden: true

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
@@ -45,8 +45,8 @@ connectionSpecification:
         kyvejs/tendermint or kyvejs/tendermint-bsync runtime. (Comma separated)
       examples:
         - "0"
+        - "50"
         - "0,0"
-        - "42000"
     end_keys:
       type: string
       title: End keys
@@ -59,7 +59,6 @@ connectionSpecification:
       examples:
         - "100"
         - "20,10"
-        - "42300"
     max_pages:
       type: integer
       description:

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
@@ -7,12 +7,12 @@ connectionSpecification:
     - pool_ids
     - start_ids
     - url_base
+  additionalProperties: true
   properties:
     pool_ids:
       type: string
       title: Pool-IDs
       description: The IDs of the KYVE storage pool you want to archive. (Comma separated)
-      order: 0
       examples:
         - "0"
         - "0,1"
@@ -22,7 +22,6 @@ connectionSpecification:
       description:
         The start-id defines, from which bundle id the pipeline should
         start to extract the data. (Comma separated)
-      order: 1
       examples:
         - "0"
         - "0,0"
@@ -32,7 +31,6 @@ connectionSpecification:
       title: KYVE-API URL Base
       description: URL to the KYVE Chain API.
       default: https://api.kyve.network
-      order: 2
       examples:
         - https://api.kaon.kyve.network/
         - https://api.korellia.kyve.network/
@@ -45,24 +43,19 @@ connectionSpecification:
         start at a specific key with a predefined Bundle-Start-ID to prevent 
         inefficiency. Right now, this is only supported for pools using the 
         kyvejs/tendermint or kyvejs/tendermint-bsync runtime. (Comma separated)
-      order: 3
       examples:
         - "0"
         - "0,0"
         - "42000"
-      default: ""
     max_pages:
       type: integer
       description:
         The maximum amount of pages to go trough. Set to 'null' for all
         pages.
-      order: 4
       airbyte_hidden: true
     page_size:
       type: integer
       description:
         The pagesize for pagination, smaller numbers are used in integration
         tests.
-      default: 100
-      order: 5
       airbyte_hidden: true

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/spec.yaml
@@ -6,7 +6,6 @@ connectionSpecification:
   required:
     - pool_ids
     - start_ids
-    - start_keys
     - url_base
   properties:
     pool_ids:
@@ -27,6 +26,7 @@ connectionSpecification:
       examples:
         - "0"
         - "0,0"
+        - "100"
     url_base:
       type: string
       title: KYVE-API URL Base
@@ -43,11 +43,14 @@ connectionSpecification:
         The start key defines, from which key the pipeline should
         start to extract the data. Only recommended when the sync should 
         start at a specific key with a predefined Bundle-Start-ID to prevent 
-        inefficiency. (Comma separated)
+        inefficiency. Right now, this is only supported for pools using the 
+        kyvejs/tendermint or kyvejs/tendermint-bsync runtime. (Comma separated)
       order: 3
       examples:
         - "0"
         - "0,0"
+        - "42000"
+      default: ""
     max_pages:
       type: integer
       description:

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
@@ -55,13 +55,17 @@ class KYVEStream(HttpStream, IncrementalMixin):
         self.runtime = pool_data.get("runtime")
 
         self.url_base = config["url_base"]
-        # this is an ugly solution but has to parsed by source to be a single item
+
         self._offset = int(config["start_ids"])
 
         self._start_key = int(config["start_keys"])
+        self._end_key = int(config["end_keys"])
+
+        self._reached_end = False
 
         self.page_size = config["page_size"]
         self.max_pages = config.get("max_pages", None)
+
         # For incremental querying
         self._cursor_value = self._offset
 
@@ -77,15 +81,15 @@ class KYVEStream(HttpStream, IncrementalMixin):
         return schema
 
     def path(
-        self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
+            self, stream_state: Mapping[str, Any] = None, stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> str:
         return f"/kyve/v1/bundles/{self.pool_id}"
 
     def request_params(
-        self,
-        stream_state: Mapping[str, Any],
-        stream_slice: Mapping[str, Any] = None,
-        next_page_token: Mapping[str, Any] = None,
+            self,
+            stream_state: Mapping[str, Any],
+            stream_slice: Mapping[str, Any] = None,
+            next_page_token: Mapping[str, Any] = None,
     ) -> MutableMapping[str, Any]:
         # Set the pagesize in the request parameters
         params = {"pagination.limit": self.page_size}
@@ -102,17 +106,17 @@ class KYVEStream(HttpStream, IncrementalMixin):
         return params
 
     def parse_response(
-        self,
-        response: requests.Response,
-        stream_state: Mapping[str, Any],
-        stream_slice: Mapping[str, Any] = None,
-        next_page_token: Mapping[str, Any] = None,
+            self,
+            response: requests.Response,
+            stream_state: Mapping[str, Any],
+            stream_slice: Mapping[str, Any] = None,
+            next_page_token: Mapping[str, Any] = None,
     ) -> Iterable[Mapping]:
         try:
             # set the state to store the latest bundle_id
             bundles = response.json().get("finalized_bundles")
             if not len(bundles):
-                self._offset = -float("inf")
+                self._reached_end = True
         except IndexError:
             bundles = []
 
@@ -160,8 +164,16 @@ class KYVEStream(HttpStream, IncrementalMixin):
                     self._cursor_value = int(bundle.get("id")) + 1
                     continue
 
-                if int(bundle.get("from_key")) <= self._start_key < int(bundle.get("to_key")):
+                if int(bundle.get("from_key")) <= self._start_key <= int(bundle.get("to_key")):
                     decompressed_as_json = [data_item for data_item in decompressed_as_json if int(data_item.get("key")) >= self._start_key]
+
+                if int(bundle.get("from_key")) > self._end_key <= int(bundle.get("to_key")):
+                    decompressed_as_json = [data_item for data_item in decompressed_as_json if int(data_item.get("key")) <= self._end_key]
+                    self._reached_end = True
+
+                if int(bundle.get("from_key")) > self._end_key:
+                    self._reached_end = True
+                    yield from []
 
                 # Set cursor value to next bundle id
                 self._cursor_value = int(bundle.get("id")) + 1
@@ -174,10 +186,12 @@ class KYVEStream(HttpStream, IncrementalMixin):
         if self.max_pages and self._cursor_value >= self.max_pages * self.page_size:
             return
 
-        if self._offset > -float("inf"):
-            self._offset = self._cursor_value
-            return str(self._offset)
         self._offset = self._cursor_value
+
+        if self._reached_end:
+            return
+        else:
+            return str(self._offset)
 
     @property
     def state(self) -> Mapping[str, Any]:

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
@@ -157,15 +157,17 @@ class KYVEStream(HttpStream, IncrementalMixin):
                 decompressed_as_json = json.loads(decompressed)
 
                 if int(bundle.get("to_key")) < self._start_key:
+                    self._cursor_value = int(bundle.get("id")) + 1
                     continue
 
-                if int(bundle.get("from:key")) <= self._start_key < int(bundle.get("to_key")):
+                if int(bundle.get("from_key")) <= self._start_key < int(bundle.get("to_key")):
                     decompressed_as_json = [data_item for data_item in decompressed_as_json if int(data_item.get("key")) >= self._start_key]
 
                 # Set cursor value to next bundle id
                 self._cursor_value = int(bundle.get("id")) + 1
                 # extract the value from the key -> value mapping
                 yield from decompressed_as_json
+            yield from []
 
     def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
         # in case we set a max_pages parameter we need to abort

--- a/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
+++ b/airbyte-integrations/connectors/source-kyve/source_kyve/stream.py
@@ -74,7 +74,7 @@ class KYVEStream(HttpStream, IncrementalMixin):
         schema = {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "type": "object",
-            "properties": {"key": {"type": "string"}, "value": {"type": "any"}},
+            "properties": {"key": {"type": "string"}, "value": {"type": "any"}, "offset": {"type": "string"}},
             "required": ["key", "value"],
         }
 
@@ -167,7 +167,7 @@ class KYVEStream(HttpStream, IncrementalMixin):
                 if int(bundle.get("from_key")) <= self._start_key <= int(bundle.get("to_key")):
                     decompressed_as_json = [data_item for data_item in decompressed_as_json if int(data_item.get("key")) >= self._start_key]
 
-                if int(bundle.get("from_key")) > self._end_key <= int(bundle.get("to_key")):
+                if int(bundle.get("from_key")) <= self._end_key <= int(bundle.get("to_key")):
                     decompressed_as_json = [data_item for data_item in decompressed_as_json if int(data_item.get("key")) <= self._end_key]
                     self._reached_end = True
 

--- a/airbyte-integrations/connectors/source-kyve/unit_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-kyve/unit_tests/__init__.py
@@ -8,6 +8,7 @@ config = {
     "start_ids": "0",
     "url_base": "https://api.korellia.kyve.network",
     "start_keys": "0",
+    "end_keys": "9999999999",
     "page_size": 100
 }
 

--- a/airbyte-integrations/connectors/source-kyve/unit_tests/__init__.py
+++ b/airbyte-integrations/connectors/source-kyve/unit_tests/__init__.py
@@ -7,6 +7,7 @@ config = {
     "pool_ids": "0",
     "start_ids": "0",
     "url_base": "https://api.korellia.kyve.network",
+    "start_keys": "0",
     "page_size": 100
 }
 

--- a/airbyte-integrations/connectors/source-kyve/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-kyve/unit_tests/test_streams.py
@@ -171,6 +171,7 @@ def test_parse_response(patch_base_class, monkeypatch):
                 },
             },
         },
+        "offset": "0"
     }
 
     assert next(stream.parse_response(**inputs)) == expected_parsed_object


### PR DESCRIPTION
This PR extends the KYVE source spec with `start_keys`. This enables a simple and comfortable way to spin up new streams independently without the risk of data gaps and duplicated rows.